### PR TITLE
Documented defaults timeout values in the EnhancedBigtableStubSettings

### DIFF
--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -194,24 +194,21 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for calls to ReadRows.
    *
-   * <p>This is idempotent and streaming operation. Retries will be attempted if RPC failed with
-   * {@link Code#DEADLINE_EXCEEDED} and {@link Code#UNAVAILABLE} failure code.
+   * <p>This is idempotent and streaming operation.
    *
    * <p>The idle timeout is configured via {@code ServerStreamingCallSettings#getIdleTimeout}. This
    * timer will terminate any stream that has not has seen any demand or activity in the configured
    * interval. To turn off idle checks, set the idleTimeout to {@link Duration#ZERO}.
    *
-   * <p>Default retry values for this operation are:
+   * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
+   * Code#UNAVAILABLE} failure code.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 60 min or 1 hour.
-   * </ul>
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * reattempt till a max retry timeout value of 60 seconds.
+   *
+   * <p>RPC timeout is 20 seconds.
+   *
+   * <p>Total timeout for this operation is 60 mins or 1 hour.
    *
    * @see RetrySettings for more explanation.
    */
@@ -222,20 +219,17 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for calls to SampleRowKeys.
    *
-   * <p>This is idempotent and non-streaming operation. Retries will be attempted if RPC failed with
-   * {@link Code#DEADLINE_EXCEEDED} and {@link Code#UNAVAILABLE} failure code.
+   * <p>This is idempotent and non-streaming operation.
    *
-   * <p>Default retry values for this operation are:
+   * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
+   * Code#UNAVAILABLE} failure code.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * reattempt till a max retry timeout value of 60 seconds.
+   *
+   * <p>RPC timeout is 20 seconds.
+   *
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * @see RetrySettings for more explanation.
    */
@@ -246,20 +240,19 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for point reads via ReadRows.
    *
-   * <p>This is an idempotent and non-streaming operation. Retries will be attempted if RPC failed
-   * with {@link Code#DEADLINE_EXCEEDED} and {@link Code#UNAVAILABLE} failure code.
+   * <p>This is an idempotent and non-streaming operation.
    *
-   * <p>Default retry values for this operation are:
+   * <p>
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
+   * Code#UNAVAILABLE} failure code.
+   *
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * reattempt till a max retry timeout value of 60 seconds.
+   *
+   * <p>RPC timeout is 20 seconds.
+   *
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * @see RetrySettings for more explanation.
    */
@@ -270,20 +263,17 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for calls to MutateRow.
    *
-   * <p>This is an idempotent and non-streaming operation. Retries will be attempted if RPC failed
-   * with {@link Code#DEADLINE_EXCEEDED} and {@link Code#UNAVAILABLE} failure code.
+   * <p>This is an idempotent and non-streaming operation.
    *
-   * <p>Default retry values for this operation are:
+   * <p>Retries will be attempted if RPC failed * with {@link Code#DEADLINE_EXCEEDED} and {@link
+   * Code#UNAVAILABLE} failure code.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * reattempt till a max retry timeout value of 60 seconds.
+   *
+   * <p>RPC timeout is 20 seconds.
+   *
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * @see RetrySettings for more explanation.
    */
@@ -299,19 +289,14 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * {@link RowMutation} request signature is ignored for the manual batched calls.
    *
    * <p>Retries will be attempted if RPC are failed with {@link Code#DEADLINE_EXCEEDED}, {@link
-   * Code#UNAVAILABLE} and {@link Code#ABORTED} failure code.
+   * Code#UNAVAILABLE} or {@link Code#ABORTED} failure code.
    *
-   * <p>Default retry values for this operation are:
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * reattempt till a max retry timeout value of 60 seconds.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>RPC timeout is 20 seconds.
+   *
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * <p>On breach of certain triggers, this batch will initiates processing of accumulated requests.
    * These triggered could be configured via {@link BatchingSettings}. Currently it triggers when:
@@ -322,8 +307,9 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    *   <li>An interval of 1 second passes after batching initialization or last processed batch.
    * </ul>
    *
-   * <p>When size of the request in processing state reaches 100MB Or their count reaches 1000 then
-   * the batching are blocked from adding new values into the ongoing batch.
+   * <p>When size of the request in processing state reaches default value of 100MB or the request
+   * count reaches default count of 1000 then the batching will be blocked till some of the request
+   * resolves.
    *
    * @see RetrySettings for more explanation.
    * @see BatchingSettings for batch related configuration explanation.
@@ -335,20 +321,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for calls to CheckAndMutateRow.
    *
-   * <p>This is a non-idempotent and non-streaming operation. By default no retries will be
-   * attempted in case of RPC failure.
+   * <p>This is a non-idempotent and non-streaming operation.
    *
-   * <p>Default retry values for this operation are:
+   * <p>By default non-idempotent operations would not reattempt in case of RPC failure.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * @see RetrySettings for more explanation.
    */
@@ -359,20 +336,11 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
   /**
    * Returns the object with the settings used for calls to ReadModifyWriteRow.
    *
-   * <p>This is a non-idempotent and non-streaming operation. By default no retries will be
-   * attempted in case of RPC failure.
+   * <p>This is a non-idempotent and non-streaming operation.
    *
-   * <p>Default retry values for this operation are:
+   * <p>By default non-idempotent operations would not reattempt in case of RPC failure.
    *
-   * <ul>
-   *   <li>InitialRetryDelay is 0.1 seconds.
-   *   <li>RetryDelayMultiplier is 1.3 times.
-   *   <li>MaxRetryDelay is 60 seconds.
-   *   <li>InitialRpcTimeout is 20 seconds.
-   *   <li>RpcTimeoutMultiplier is linear or 1.0 times.
-   *   <li>MaxRpcTimeout is 20 seconds.
-   *   <li>TotalTimeout is 600 seconds or 10 min.
-   * </ul>
+   * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
    * @see RetrySettings for more explanation.
    */

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -55,12 +55,13 @@ import org.threeten.bp.Duration;
  *   <li>The default service address (bigtable.googleapis.com) and default port (443) are used.
  *   <li>Credentials are acquired automatically through Application Default Credentials.
  *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
- *   <li>In case of streaming operation RPC timeout applies to each row and for the non-streaming
- *       operations rpc timeout considered as deadline of each call.
- *   <li>Each setting operation accepts RPC and total timeout, Here rpc timeouts are for each
- *       attempts to get the result whereas totalTimeout applies as operation timeout.
+ *   <li>This settings are mixed for streaming and non-streaming operation. In case of streaming
+ *       operations, RPC timeout applies to each row and for the non-streaming operations, RPC
+ *       timeout considered as deadline for every call.
+ *   <li>Each operation setting accepts RPC and total time out. Here, RPC timeouts are for each
+ *       attempt to get the result whereas total timeout applies to the operation timeout.
  *   <li>RetryDelayMultiplier controls the change in retry delay. After initial attempt, subsequent
- *       attempts are calculated by multiplying the retry delay of previous call.
+ *       attempts are calculated by multiplying the retry delay of the previous call.
  * </ul>
  *
  * <p>The only required setting is the instance name.
@@ -203,7 +204,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
    * Code#UNAVAILABLE} failure code.
    *
-   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on every
    * reattempt till a max retry timeout value of 60 seconds.
    *
    * <p>RPC timeout is 20 seconds.
@@ -224,7 +225,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
    * Code#UNAVAILABLE} failure code.
    *
-   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on every
    * reattempt till a max retry timeout value of 60 seconds.
    *
    * <p>RPC timeout is 20 seconds.
@@ -247,7 +248,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * <p>Retries will be attempted if RPC failed with {@link Code#DEADLINE_EXCEEDED} and {@link
    * Code#UNAVAILABLE} failure code.
    *
-   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on every
    * reattempt till a max retry timeout value of 60 seconds.
    *
    * <p>RPC timeout is 20 seconds.
@@ -268,7 +269,7 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * <p>Retries will be attempted if RPC failed * with {@link Code#DEADLINE_EXCEEDED} and {@link
    * Code#UNAVAILABLE} failure code.
    *
-   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on every
    * reattempt till a max retry timeout value of 60 seconds.
    *
    * <p>RPC timeout is 20 seconds.
@@ -291,15 +292,15 @@ public class EnhancedBigtableStubSettings extends StubSettings<EnhancedBigtableS
    * <p>Retries will be attempted if RPC are failed with {@link Code#DEADLINE_EXCEEDED}, {@link
    * Code#UNAVAILABLE} or {@link Code#ABORTED} failure code.
    *
-   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on each
+   * <p>RetryDelay starts with 100ms or 0.1 seconds, which multiplies with 1.3 times on every
    * reattempt till a max retry timeout value of 60 seconds.
    *
    * <p>RPC timeout is 20 seconds.
    *
    * <p>Total timeout for this operation is 600 seconds or 10 mins.
    *
-   * <p>On breach of certain triggers, this batch will initiates processing of accumulated requests.
-   * These triggered could be configured via {@link BatchingSettings}. Currently it triggers when:
+   * <p>On breach of certain triggers, this batch initiates the processing of accumulated requests.
+   * These triggers could be configured via {@link BatchingSettings}. Currently it triggers when:
    *
    * <ul>
    *   <li>100 or more requests are sent.

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -55,7 +55,7 @@ import org.threeten.bp.Duration;
  *   <li>The default service address (bigtable.googleapis.com) and default port (443) are used.
  *   <li>Credentials are acquired automatically through Application Default Credentials.
  *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
- *   <li>Here is the default for Bigtable operation:
+ *   <li>These are the default timeouts used Bigtable operations.
  *       <ul>
  *         For non-streaming operations i.e. {@link #readRowSettings()}, {@link
  *         #sampleRowKeysSettings()}, {@link #checkAndMutateRowSettings()} {@link

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStubSettings.java
@@ -55,6 +55,24 @@ import org.threeten.bp.Duration;
  *   <li>The default service address (bigtable.googleapis.com) and default port (443) are used.
  *   <li>Credentials are acquired automatically through Application Default Credentials.
  *   <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ *   <li>Here is the default for Bigtable operation:
+ *       <ul>
+ *         For non-streaming operations i.e. {@link #readRowSettings()}, {@link
+ *         #sampleRowKeysSettings()}, {@link #checkAndMutateRowSettings()} {@link
+ *         #mutateRowSettings()}, {@link #bulkMutateRowsSettings()} {@link
+ *         #readModifyWriteRowSettings()}:
+ *         <li>Default timeout for {@link RetrySettings#getInitialRpcTimeout()} is 20_000ms.
+ *         <li>Default timeout for {@link RetrySettings#getMaxAttempts()} is 20_000ms.
+ *         <li>Default timeout for {@link RetrySettings#getTotalTimeout()} is 600_000ms or 10min.
+ *       </ul>
+ *       <ul>
+ *         For streaming operation i.e. {@link #readRowsSettings()}:
+ *         <li>Default timeout for {@link ServerStreamingCallSettings#getIdleTimeout()} is
+ *             300_000ms.
+ *         <li>Default timeout for {@link RetrySettings#getInitialRpcTimeout()} is 20_000ms.
+ *         <li>Default timeout for {@link RetrySettings#getMaxAttempts()} is 20_000ms.
+ *         <li>Default timeout for {@link RetrySettings#getTotalTimeout()} is 3_600_000ms or 60min.
+ *       </ul>
  * </ul>
  *
  * <p>The only required setting is the instance name.


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)

This is related to an already opened PR. Comments received over there are:

> I would collapse the rpc timeout min/max/multiplier settings into a single constant rpc timeout value in the docs

And

> This needs a lot of work and should probably be in its own paragraph and/or in each method doc:
> 
> * A distinction should be drawn between idempotent methods (ReadRow(s), MutateRow(s), SampleRowKeys) and non-idempotent methods (CheckAndMutateRows, ReadModiifyWrite)
> * The distinction for streaming vs non-streaming should be kept. But there needs to be some explanation about how the settings apply. For example rpc timeout for non-streaming is the deadline for each call, but for streaming the rpc timeout is the timeout between each row.
> * There should be docs explaining what rpc timeout is vs total timeout (ie. attempt timeout vs operation timeout)
> * The values should be human readable, ie instead of 20_000ms, it should be 20 seconds
> * There should be docs about exponential delay defaults
> * There should be an explanation of what idleTimeout is
> * The formatting is currently invalid: `<ul>TEXT<li>first element text` is not valid markup

