### PR TITLE
Updated `UnsafeByteOperations.unsafeWrap` to `ByteString.copyFrom`

### DIFF
--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Range.java
@@ -19,7 +19,6 @@ import com.google.api.core.InternalExtensionOnly;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -360,7 +359,7 @@ public abstract class Range<T, R extends Range<T, R>> implements Serializable {
       }
 
       ByteString endPrefix = offset == 0 ? ByteString.EMPTY : prefix.substring(0, offset);
-      ByteString endSuffix = UnsafeByteOperations.unsafeWrap(new byte[] {(byte) (curByte + 1)});
+      ByteString endSuffix = ByteString.copyFrom(new byte[] {(byte) (curByte + 1)});
       ByteString end = endPrefix.concat(endSuffix);
 
       ByteStringRange range = ByteStringRange.unbounded().startClosed(prefix);


### PR DESCRIPTION
Updated `UnsafeByteOperations.unsafeWrap` as this is still a `@ExperimentalApi`.

Call this method(i.e. Range.ByteRangeString#prefix 1 million times, I observed that with UnsafeByteOperations.unsafeWrap their avg is around ~200ms. after update with `ByteString.copyFrom` the new avg is ~220ms.(10% decrement to pref).

I hope this should be ok. as the `prefix` is not performance intensive (as per Igor's comment in last call).