### PR TITLE
Connecting to Bigtable emulator using environment variable

### DIFF
--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettings.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.admin.v2;
 
+import static com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings.BIGTABLE_EMULATOR_HOST_ENV_VAR;
+
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableInstanceAdminStubSettings;
 import com.google.common.base.Preconditions;
@@ -79,6 +81,9 @@ public final class BigtableInstanceAdminSettings {
 
   /** Returns a new builder for this class. */
   public static Builder newBuilder() {
+    Preconditions.checkState(
+        System.getenv(BIGTABLE_EMULATOR_HOST_ENV_VAR) == null,
+        "BigtableInstanceAdminSettings doesn't supported on Emulator");
     return new Builder();
   }
 

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
@@ -124,7 +124,7 @@ public final class BigtableTableAdminSettings {
    * number.
    */
   public static Builder newBuilderForEmulator(String hostname, int port) {
-    Builder builder = new Builder().setProjectId("fake-project").setInstanceId("fake-instance");
+    Builder builder = new Builder();
 
     builder
         .stubSettings()

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminSettings.java
@@ -21,6 +21,7 @@ import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.base.Verify;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
@@ -97,14 +98,14 @@ public final class BigtableTableAdminSettings {
    */
   public static Builder newBuilder() {
     String hostAndPort = System.getenv(BIGTABLE_EMULATOR_HOST_ENV_VAR);
-    if (hostAndPort != null && !hostAndPort.isEmpty()) {
+    if (!Strings.isNullOrEmpty(hostAndPort)) {
       int port;
       try {
         port = Integer.parseInt(hostAndPort.substring(hostAndPort.lastIndexOf(":") + 1));
         return newBuilderForEmulator(hostAndPort.substring(0, hostAndPort.lastIndexOf(":")), port);
-      } catch (NumberFormatException ex) {
+      } catch (NumberFormatException | IndexOutOfBoundsException ex) {
         throw new RuntimeException(
-            "Invalid port in "
+            "Invalid host/port in "
                 + BIGTABLE_EMULATOR_HOST_ENV_VAR
                 + " environment variable: "
                 + hostAndPort);
@@ -119,7 +120,8 @@ public final class BigtableTableAdminSettings {
   }
 
   /**
-   * Create a new builder preconfigured to connect to the Bigtable emulator with host & port number.
+   * Creates a new builder preconfigured to connect to the Bigtable emulator with host name and port
+   * number.
    */
   public static Builder newBuilderForEmulator(String hostname, int port) {
     Builder builder = new Builder().setProjectId("fake-project").setInstanceId("fake-instance");

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -23,6 +23,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.common.base.Strings;
 import io.grpc.ManagedChannelBuilder;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
@@ -74,14 +75,14 @@ public final class BigtableDataSettings {
    */
   public static Builder newBuilder() {
     String hostAndPort = System.getenv(BIGTABLE_EMULATOR_HOST_ENV_VAR);
-    if (hostAndPort != null && !hostAndPort.isEmpty()) {
+    if (!Strings.isNullOrEmpty(hostAndPort)) {
       try {
         int lastIndexOfCol = hostAndPort.lastIndexOf(":");
         int port = Integer.parseInt(hostAndPort.substring(lastIndexOfCol + 1));
         return newBuilderForEmulator(hostAndPort.substring(0, lastIndexOfCol), port);
-      } catch (NumberFormatException ex) {
+      } catch (NumberFormatException | IndexOutOfBoundsException ex) {
         throw new RuntimeException(
-            "Invalid port in "
+            "Invalid host/port in "
                 + BIGTABLE_EMULATOR_HOST_ENV_VAR
                 + " environment variable: "
                 + hostAndPort);
@@ -96,15 +97,14 @@ public final class BigtableDataSettings {
   }
 
   /**
-   * Create a new builder preconfigured to connect to the Bigtable emulator with o host & port name.
+   * Creates a new builder preconfigured to connect to the Bigtable emulator with a host name and
+   * port number.
    */
   public static Builder newBuilderForEmulator(String hostname, int port) {
-    Builder builder = new Builder();
+    Builder builder = new Builder().setProjectId("fake-project").setInstanceId("fake-instance");
 
     builder
         .stubSettings()
-        .setProjectId("fake-project")
-        .setInstanceId("fake-instance")
         .setCredentialsProvider(NoCredentialsProvider.create())
         .setEndpoint(hostname + ":" + port)
         .setTransportChannelProvider(

--- a/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/BigtableDataSettings.java
@@ -101,7 +101,7 @@ public final class BigtableDataSettings {
    * port number.
    */
   public static Builder newBuilderForEmulator(String hostname, int port) {
-    Builder builder = new Builder().setProjectId("fake-project").setInstanceId("fake-instance");
+    Builder builder = new Builder();
 
     builder
         .stubSettings()

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/EmulatorEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/EmulatorEnv.java
@@ -39,10 +39,16 @@ public class EmulatorEnv implements TestEnv {
 
     tableAdminClient =
         BigtableTableAdminClient.create(
-            BigtableTableAdminSettings.newBuilderForEmulator(emulator.getPort()).build());
+            BigtableTableAdminSettings.newBuilderForEmulator(emulator.getPort())
+                .setProjectId("fake-project")
+                .setInstanceId("fake-instance")
+                .build());
     dataClient =
         BigtableDataClient.create(
-            BigtableDataSettings.newBuilderForEmulator(emulator.getPort()).build());
+            BigtableDataSettings.newBuilderForEmulator(emulator.getPort())
+                .setProjectId("fake-project")
+                .setInstanceId("fake-instance")
+                .build());
 
     tableAdminClient.createTable(CreateTableRequest.of(TABLE_ID).addFamily(FAMILY_ID));
   }

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.bigtable.data.v2.it.env;
 
+import com.google.common.truth.TruthJUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -47,7 +47,11 @@ public class TestEnvRule extends ExternalResource {
 
   @Override
   protected void before() throws Throwable {
-    Assume.assumeTrue(System.getenv(BIGTABLE_EMULATOR_HOST_ENV_VAR) == null);
+    TruthJUnit.assume()
+        .withMessage(
+            "Integration tests can't run with the BIGTABLE_EMULATOR_HOST_ENV_VAR environment variable set. Please use the emulator-it maven profile instead")
+        .that(System.getenv())
+        .doesNotContainKey(BIGTABLE_EMULATOR_HOST_ENV_VAR);
     String env = System.getProperty(ENV_PROPERTY, "emulator");
 
     switch (env) {

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.bigtable.data.v2.it.env;
 
-import com.google.common.truth.TruthJUnit;
+import static com.google.common.truth.TruthJUnit.assume;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.rules.ExternalResource;
@@ -38,18 +39,19 @@ import org.junit.rules.ExternalResource;
  * <p>By default, {@code emulator} will be used
  */
 public class TestEnvRule extends ExternalResource {
+
   private static final Logger LOGGER = Logger.getLogger(TestEnvRule.class.getName());
   private static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
-
   private static final String ENV_PROPERTY = "bigtable.env";
 
   private TestEnv testEnv;
 
   @Override
   protected void before() throws Throwable {
-    TruthJUnit.assume()
+    assume()
         .withMessage(
-            "Integration tests can't run with the BIGTABLE_EMULATOR_HOST_ENV_VAR environment variable set. Please use the emulator-it maven profile instead")
+            "Integration tests can't run with the BIGTABLE_EMULATOR_HOST environment variable set"
+                + ". Please use the emulator-it maven profile instead")
         .that(System.getenv())
         .doesNotContainKey(BIGTABLE_EMULATOR_HOST_ENV_VAR);
     String env = System.getProperty(ENV_PROPERTY, "emulator");

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/env/TestEnvRule.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.it.env;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -38,6 +39,7 @@ import org.junit.rules.ExternalResource;
  */
 public class TestEnvRule extends ExternalResource {
   private static final Logger LOGGER = Logger.getLogger(TestEnvRule.class.getName());
+  private static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
 
   private static final String ENV_PROPERTY = "bigtable.env";
 
@@ -45,6 +47,7 @@ public class TestEnvRule extends ExternalResource {
 
   @Override
   protected void before() throws Throwable {
+    Assume.assumeTrue(System.getenv(BIGTABLE_EMULATOR_HOST_ENV_VAR) == null);
     String env = System.getProperty(ENV_PROPERTY, "emulator");
 
     switch (env) {


### PR DESCRIPTION
Now user can connect to Bigtable emulator in three ways:
 - By settings hostName:portNum in BIGTABLE_EMULATOR_HOST environment variable.
 - By providing only the port number within the local workstation.
 - By providing hostName & port Number.
