### PR TITLE
Adding Integration Test of BigtableInstanceAdminClient

### DIFF
--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableInstanceAdminClientIT.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.admin.v2.it;
+
+import static com.google.cloud.bigtable.test_helpers.env.AbstractTestEnv.TEST_APP_PREFIX;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.TruthJUnit.assume;
+
+import com.google.cloud.Policy;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.AppProfile;
+import com.google.cloud.bigtable.admin.v2.models.Cluster;
+import com.google.cloud.bigtable.admin.v2.models.CreateAppProfileRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateClusterRequest;
+import com.google.cloud.bigtable.admin.v2.models.CreateInstanceRequest;
+import com.google.cloud.bigtable.admin.v2.models.Instance;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.admin.v2.models.UpdateAppProfileRequest;
+import com.google.cloud.bigtable.admin.v2.models.UpdateInstanceRequest;
+import com.google.cloud.bigtable.test_helpers.env.AbstractTestEnv;
+import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
+import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
+import java.util.List;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.threeten.bp.Instant;
+
+public class BigtableInstanceAdminClientIT {
+
+  @ClassRule public static TestEnvRule testEnvRule = new TestEnvRule();
+
+  private String instanceId = testEnvRule.env().getInstanceId();
+  private BigtableInstanceAdminClient client;
+
+  // TODO: Update this test once emulator supports InstanceAdmin operation
+  // https://github.com/googleapis/google-cloud-go/issues/1069
+  @BeforeClass
+  public static void validatePlatform() {
+    assume()
+        .withMessage("BigtableInstanceAdminClient doesn't support on Emulator")
+        .that(testEnvRule.env())
+        .isNotInstanceOf(EmulatorEnv.class);
+  }
+
+  @Before
+  public void setUp() {
+    client = testEnvRule.env().getInstanceAdminClient();
+  }
+
+  @Test
+  public void appProfileTest() {
+    String testAppProfile = TEST_APP_PREFIX + Instant.now().getEpochSecond();
+
+    AppProfile newlyCreatedAppProfile =
+        client.createAppProfile(
+            CreateAppProfileRequest.of(instanceId, testAppProfile)
+                .setRoutingPolicy(AppProfile.MultiClusterRoutingPolicy.of())
+                .setDescription("This is to test app profile"));
+
+    AppProfile updated =
+        client.updateAppProfile(
+            UpdateAppProfileRequest.of(newlyCreatedAppProfile)
+                .setDescription("This is to app profile operation"));
+
+    AppProfile freshAppProfile = client.getAppProfile(instanceId, testAppProfile);
+    assertThat(freshAppProfile.getDescription()).isEqualTo(updated.getDescription());
+
+    assertThat(client.listAppProfiles(instanceId)).contains(freshAppProfile);
+
+    Exception actualEx = null;
+    try {
+      client.deleteAppProfile(instanceId, testAppProfile, true);
+    } catch (Exception ex) {
+      actualEx = ex;
+    }
+    assertThat(actualEx).isNull();
+  }
+
+  @Test
+  public void iamUpdateTest() {
+    Policy policy = client.getIamPolicy(instanceId);
+    assertThat(policy).isNotNull();
+
+    Exception actualEx = null;
+    try {
+      assertThat(client.setIamPolicy(instanceId, policy)).isNotNull();
+    } catch (Exception iamException) {
+      actualEx = iamException;
+    }
+    assertThat(actualEx).isNull();
+
+    List<String> permissions =
+        client.testIamPermission(
+            instanceId, "bigtable.tables.readRows", "bigtable.tables.mutateRows");
+    assertThat(permissions).hasSize(2);
+  }
+
+  @Test
+  public void instanceCreationDeletionTest() {
+    String newInstanceId = AbstractTestEnv.TEST_INSTANCE_PREFIX + Instant.now().getEpochSecond();
+    String newClusterId = newInstanceId + "-c1";
+
+    client.createInstance(
+        CreateInstanceRequest.of(newInstanceId)
+            .addCluster(newClusterId, "us-central1-a", 0, StorageType.SSD)
+            .setDisplayName("Fresh-Instance-Name")
+            .addLabel("state", "readytodelete")
+            .setType(Instance.Type.DEVELOPMENT));
+
+    try {
+      assertThat(client.exists(newInstanceId)).isTrue();
+
+      client.updateInstance(
+          UpdateInstanceRequest.of(newInstanceId).setDisplayName("Test-Instance-Name"));
+
+      Instance instance = client.getInstance(newInstanceId);
+      assertThat(instance.getDisplayName()).isEqualTo("Test-Instance-Name");
+
+      assertThat(client.listInstances()).contains(instance);
+
+      client.deleteInstance(newInstanceId);
+      assertThat(client.exists(newInstanceId)).isFalse();
+    } finally {
+      if (client.exists(newInstanceId)) {
+        client.deleteInstance(newInstanceId);
+      }
+    }
+  }
+
+  @Test
+  public void clusterCreationDeletionTest() {
+    Instance currentInstance = client.getInstance(instanceId);
+    assume()
+        .withMessage("cluster replication test can only run on PRODUCTION instance")
+        .that(currentInstance.getType())
+        .isEqualTo(Instance.Type.PRODUCTION);
+
+    String newClusterId = AbstractTestEnv.TEST_CLUSTER_PREFIX + Instant.now().getEpochSecond();
+    boolean isClusterDeleted = false;
+    client.createCluster(
+        CreateClusterRequest.of(instanceId, newClusterId)
+            .setZone("us-central1-f")
+            .setStorageType(StorageType.SSD)
+            .setServeNodes(3));
+    try {
+      assertThat(client.getCluster(instanceId, newClusterId)).isNotNull();
+
+      client.deleteCluster(instanceId, newClusterId);
+      isClusterDeleted = true;
+    } finally {
+      if (!isClusterDeleted) {
+        client.deleteCluster(instanceId, newClusterId);
+      }
+    }
+  }
+
+  /* As cluster creation is very expensive operation, so reusing existing clusters to verify rest
+  of the operation.*/
+  @Test
+  public void basicInstanceOperationTest() {
+    assertThat(client.exists(instanceId)).isTrue();
+
+    client.updateInstance(
+        UpdateInstanceRequest.of(instanceId).setDisplayName("Updated-Instance-Name"));
+
+    Instance instance = client.getInstance(instanceId);
+    assertThat(instance.getDisplayName()).isEqualTo("Updated-Instance-Name");
+
+    assertThat(client.listInstances()).contains(instance);
+  }
+
+  /* As cluster creation is very expensive operation, so reusing existing clusters to verify rest
+  of the operation.*/
+  @Test
+  public void basicClusterOperationTest() {
+    List<Cluster> clusters = client.listClusters(instanceId);
+    assertThat(clusters).isNotEmpty();
+
+    Cluster existingCluster = clusters.get(0);
+    String clusterId = existingCluster.getId();
+    assertThat(client.getCluster(instanceId, clusterId)).isEqualTo(existingCluster);
+
+    if (Instance.Type.PRODUCTION.equals(client.getInstance(instanceId).getType())) {
+      int existingClusterNodeSize = existingCluster.getServeNodes();
+      int freshNumOfNodes = existingClusterNodeSize + 1;
+
+      Cluster resizeCluster = client.resizeCluster(instanceId, clusterId, freshNumOfNodes);
+      assertThat(resizeCluster.getServeNodes()).isEqualTo(freshNumOfNodes);
+
+      assertThat(client.resizeCluster(instanceId, clusterId, existingClusterNodeSize))
+          .isEqualTo(existingClusterNodeSize);
+    }
+  }
+}

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -15,7 +15,11 @@
  */
 package com.google.cloud.bigtable.test_helpers.env;
 
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.AppProfile;
+import com.google.cloud.bigtable.admin.v2.models.Cluster;
+import com.google.cloud.bigtable.admin.v2.models.Instance;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import org.threeten.bp.Instant;
 import org.threeten.bp.temporal.ChronoUnit;
@@ -27,6 +31,9 @@ import org.threeten.bp.temporal.ChronoUnit;
  */
 public abstract class AbstractTestEnv {
   private static final String PREFIX = "temp-";
+  public static final String TEST_INSTANCE_PREFIX = "temp-instance-";
+  public static final String TEST_CLUSTER_PREFIX = "temp-cluster-";
+  public static final String TEST_APP_PREFIX = "temp-Ap-";
 
   abstract void start() throws Exception;
 
@@ -35,6 +42,8 @@ public abstract class AbstractTestEnv {
   public abstract BigtableDataClient getDataClient();
 
   public abstract BigtableTableAdminClient getTableAdminClient();
+
+  public abstract BigtableInstanceAdminClient getInstanceAdminClient();
 
   public abstract String getProjectId();
 
@@ -71,6 +80,45 @@ public abstract class AbstractTestEnv {
       }
       if (stalePrefix.compareTo(tableId) > 0) {
         getTableAdminClient().deleteTable(tableId);
+      }
+    }
+  }
+
+  void cleanUpInstances() {
+    cleanUpStaleAppProfile();
+    cleanUpStaleClusters();
+    cleanUpStaleInstances();
+  }
+
+  private void cleanUpStaleAppProfile() {
+    String staleAPPattern = TEST_APP_PREFIX + Instant.now().minus(1, ChronoUnit.DAYS);
+
+    for (AppProfile appProfile : getInstanceAdminClient().listAppProfiles(getInstanceId())) {
+      String appProfileId = appProfile.getId();
+      if (appProfileId.startsWith(staleAPPattern) && staleAPPattern.compareTo(appProfileId) > 0) {
+        getInstanceAdminClient().deleteAppProfile(getInstanceId(), appProfileId, true);
+      }
+    }
+  }
+
+  private void cleanUpStaleClusters() {
+    String staleClusterId = TEST_CLUSTER_PREFIX + Instant.now().minus(1, ChronoUnit.DAYS);
+
+    for (Cluster cluster : getInstanceAdminClient().listClusters(getInstanceId())) {
+      String clusterId = cluster.getId();
+      if (clusterId.startsWith(staleClusterId) && staleClusterId.compareTo(clusterId) > 0) {
+        getInstanceAdminClient().deleteCluster(getInstanceId(), clusterId);
+      }
+    }
+  }
+
+  private void cleanUpStaleInstances() {
+    String staleInstanceId = TEST_INSTANCE_PREFIX + Instant.now().minus(1, ChronoUnit.DAYS);
+
+    for (Instance ins : getInstanceAdminClient().listInstances()) {
+      String insId = ins.getId();
+      if (insId.startsWith(staleInstanceId) && staleInstanceId.compareTo(insId) > 0) {
+        getInstanceAdminClient().deleteInstance(insId);
       }
     }
   }

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/AbstractTestEnv.java
@@ -67,8 +67,17 @@ public abstract class AbstractTestEnv {
     return String.format(PREFIX + "015%d", instant.getEpochSecond());
   }
 
+  public boolean isInstanceAdminSupported() {
+    return true;
+  }
+
   void cleanUpStale() {
     cleanupStaleTables();
+    if (isInstanceAdminSupported()) {
+      cleanUpStaleAppProfile();
+      cleanUpStaleClusters();
+      cleanUpStaleInstances();
+    }
   }
 
   private void cleanupStaleTables() {
@@ -82,12 +91,6 @@ public abstract class AbstractTestEnv {
         getTableAdminClient().deleteTable(tableId);
       }
     }
-  }
-
-  void cleanUpInstances() {
-    cleanUpStaleAppProfile();
-    cleanUpStaleClusters();
-    cleanUpStaleInstances();
   }
 
   private void cleanUpStaleAppProfile() {

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/DirectPathEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/DirectPathEnv.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.test_helpers.env;
 
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
@@ -54,6 +55,7 @@ public class DirectPathEnv extends AbstractTestEnv {
 
   private BigtableDataClient dataClient;
   private BigtableTableAdminClient tableAdminClient;
+  private BigtableInstanceAdminClient instanceAdminClient;
 
   static DirectPathEnv create() {
     return new DirectPathEnv(
@@ -93,12 +95,14 @@ public class DirectPathEnv extends AbstractTestEnv {
 
     dataClient = BigtableDataClient.create(settingsBuilder.build());
     tableAdminClient = BigtableTableAdminClient.create(projectId, instanceId);
+    instanceAdminClient = BigtableInstanceAdminClient.create(projectId);
   }
 
   @Override
   void stop() throws Exception {
     dataClient.close();
     tableAdminClient.close();
+    instanceAdminClient.close();
   }
 
   @Override
@@ -109,6 +113,11 @@ public class DirectPathEnv extends AbstractTestEnv {
   @Override
   public BigtableTableAdminClient getTableAdminClient() {
     return tableAdminClient;
+  }
+
+  @Override
+  public BigtableInstanceAdminClient getInstanceAdminClient() {
+    return instanceAdminClient;
   }
 
   @Override

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.test_helpers.env;
 
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
@@ -88,5 +89,10 @@ public class EmulatorEnv extends AbstractTestEnv {
   @Override
   public BigtableTableAdminClient getTableAdminClient() {
     return tableAdminClient;
+  }
+
+  @Override
+  public BigtableInstanceAdminClient getInstanceAdminClient() {
+    throw new UnsupportedOperationException("InstanceAdminClient is not supported with emulator");
   }
 }

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/EmulatorEnv.java
@@ -95,4 +95,9 @@ public class EmulatorEnv extends AbstractTestEnv {
   public BigtableInstanceAdminClient getInstanceAdminClient() {
     throw new UnsupportedOperationException("InstanceAdminClient is not supported with emulator");
   }
+
+  @Override
+  public boolean isInstanceAdminSupported() {
+    return false;
+  }
 }

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/ProdEnv.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/ProdEnv.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.test_helpers.env;
 
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminClient;
 import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import java.io.IOException;
@@ -40,6 +41,7 @@ class ProdEnv extends AbstractTestEnv {
 
   private BigtableDataClient dataClient;
   private BigtableTableAdminClient tableAdminClient;
+  private BigtableInstanceAdminClient instanceAdminClient;
 
   static ProdEnv fromSystemProperties() {
     return new ProdEnv(
@@ -58,12 +60,14 @@ class ProdEnv extends AbstractTestEnv {
   void start() throws IOException {
     dataClient = BigtableDataClient.create(projectId, instanceId);
     tableAdminClient = BigtableTableAdminClient.create(projectId, instanceId);
+    instanceAdminClient = BigtableInstanceAdminClient.create(projectId);
   }
 
   @Override
   void stop() throws Exception {
     dataClient.close();
     tableAdminClient.close();
+    instanceAdminClient.close();
   }
 
   @Override
@@ -74,6 +78,11 @@ class ProdEnv extends AbstractTestEnv {
   @Override
   public BigtableTableAdminClient getTableAdminClient() {
     return tableAdminClient;
+  }
+
+  @Override
+  public BigtableInstanceAdminClient getInstanceAdminClient() {
+    return instanceAdminClient;
   }
 
   @Override

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
@@ -43,6 +43,7 @@ public class TestEnvRule extends ExternalResource {
   private static final Logger LOGGER = Logger.getLogger(TestEnvRule.class.getName());
   private static final String BIGTABLE_EMULATOR_HOST_ENV_VAR = "BIGTABLE_EMULATOR_HOST";
   private static final String ENV_PROPERTY = "bigtable.env";
+  private static final String env = System.getProperty(ENV_PROPERTY, "emulator");
 
   private AbstractTestEnv testEnv;
 
@@ -54,7 +55,6 @@ public class TestEnvRule extends ExternalResource {
                 + ". Please use the emulator-it maven profile instead")
         .that(System.getenv())
         .doesNotContainKey(BIGTABLE_EMULATOR_HOST_ENV_VAR);
-    String env = System.getProperty(ENV_PROPERTY, "emulator");
 
     switch (env) {
       case "emulator":
@@ -79,6 +79,9 @@ public class TestEnvRule extends ExternalResource {
   protected void after() {
     try {
       env().cleanUpStale();
+      if ("prod".equals(env) || "direct_path".equals(env)) {
+        env().cleanUpInstances();
+      }
     } catch (Exception e) {
       LOGGER.log(Level.WARNING, "Failed to cleanup environment", e);
     }

--- a/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
+++ b/google-cloud-clients/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/TestEnvRule.java
@@ -79,9 +79,6 @@ public class TestEnvRule extends ExternalResource {
   protected void after() {
     try {
       env().cleanUpStale();
-      if ("prod".equals(env) || "direct_path".equals(env)) {
-        env().cleanUpInstances();
-      }
     } catch (Exception e) {
       LOGGER.log(Level.WARNING, "Failed to cleanup environment", e);
     }


### PR DESCRIPTION
This tests will not create any bigtable resource(considering instance, cluster creation is expensive) unless `createBigtableResource` property is set.
